### PR TITLE
Fix incorrect type for ‘config’ option

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -13,7 +13,7 @@ on:
       # standard parameters
       config:
         description: 'Set configuration values. Separate multiple values with a comma. The values set here override any values set in your configuration file.'
-        type: boolean
+        type: string
         required: false
       config-file:
         description: 'Path to a JSON file where configuration values are set.'


### PR DESCRIPTION
Hey @bahmutov! It looks like the `config` option should be a `string`, not a `boolean`. 

```yaml
uses: bahmutov/cypress-workflows/.github/workflows/parallel.yml@v1
with:
  n: 9
  group: 'Tests'
  config: baseUrl=${{ github.event.deployment_status.target_url }}
```

> The template is not valid. .github/workflows/tests.yml (Line: 45, Col: 16): Unexpected type of value 'baseUrl=&lt;redacted>', expected type: Boolean. 

Edit: Looking at your code and your examples, it wasn’t clear to me how to pass the base URL, so I assumed this would be the way to go.